### PR TITLE
Update to 1.20.3/4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	include (modImplementation "com.terraformersmc.terraform-api:terraform-wood-api-v1:8.0.0")
+	include (modImplementation "com.terraformersmc.terraform-api:terraform-wood-api-v1:9.0.0")
 
 	// Uncomment the following line to enable the deprecated Fabric API modules. 
 	// These are included in the Fabric API production distribution and allow you to update your mod to the latest modules at a later more convenient time.

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.parallel=true
 	loader_version=0.15.6
 
 # Mod Properties
-	mod_version = 2.1.0-1.20.2
+	mod_version = 2.1.0-1.20.4
 	maven_group = net.kenneth
 	archives_base_name = azaleawood
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ org.gradle.parallel=true
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraft_version=1.20.2
-	yarn_mappings=1.20.2+build.1
-	loader_version=0.14.22
+	minecraft_version=1.20.4
+	yarn_mappings=1.20.4+build.3
+	loader_version=0.15.6
 
 # Mod Properties
 	mod_version = 2.1.0-1.20.2
@@ -14,4 +14,4 @@ org.gradle.parallel=true
 	archives_base_name = azaleawood
 
 # Dependencies
-	fabric_version=0.89.2+1.20.2
+	fabric_version=0.95.4+1.20.4

--- a/src/main/java/net/firesteed/azaleawood/block/ModBlocks.java
+++ b/src/main/java/net/firesteed/azaleawood/block/ModBlocks.java
@@ -29,21 +29,21 @@ public class ModBlocks {
 
     public static final BlockSetType AZALEA = new BlockSetType("azalea");
     public static final Block AZALEA_BUTTON = registerBlock("azalea_button",
-            new ButtonBlock(FabricBlockSettings.copy(Blocks.OAK_BUTTON), AZALEA, 30, true));
+            new ButtonBlock(AZALEA, 30, FabricBlockSettings.copy(Blocks.OAK_BUTTON)));
     public static final Block AZALEA_PRESSURE_PLATE = registerBlock("azalea_pressure_plate",
-            new PressurePlateBlock(PressurePlateBlock.ActivationRule.EVERYTHING,
-                    FabricBlockSettings.copy(Blocks.OAK_PRESSURE_PLATE).mapColor(MapColor.TERRACOTTA_GRAY), AZALEA));
+            new PressurePlateBlock(
+                    AZALEA, FabricBlockSettings.copy(Blocks.OAK_PRESSURE_PLATE).mapColor(MapColor.TERRACOTTA_GRAY)));
 
     public static final Block AZALEA_TRAPDOOR = registerBlock("azalea_trapdoor",
-            new TrapdoorBlock(FabricBlockSettings.copy(Blocks.OAK_TRAPDOOR).mapColor(MapColor.TERRACOTTA_GRAY),
-                    AZALEA));
+            new TrapdoorBlock(AZALEA,
+                    FabricBlockSettings.copy(Blocks.OAK_TRAPDOOR).mapColor(MapColor.TERRACOTTA_GRAY)));
     public static final Block AZALEA_DOOR = registerBlock("azalea_door",
-            new DoorBlock(FabricBlockSettings.copy(Blocks.OAK_DOOR).mapColor(MapColor.TERRACOTTA_GRAY), AZALEA));
+            new DoorBlock(AZALEA, FabricBlockSettings.copy(Blocks.OAK_DOOR).mapColor(MapColor.TERRACOTTA_GRAY)));
 
     public static final WoodType AZALEA_TYPE = new WoodType("azalea", AZALEA);
     public static final Block AZALEA_FENCE_GATE = registerBlock("azalea_fence_gate",
-            new FenceGateBlock(FabricBlockSettings.copy(Blocks.OAK_FENCE_GATE).mapColor(MapColor.TERRACOTTA_GRAY),
-                    AZALEA_TYPE));
+            new FenceGateBlock(AZALEA_TYPE,
+                    FabricBlockSettings.copy(Blocks.OAK_FENCE_GATE).mapColor(MapColor.TERRACOTTA_GRAY)));
     public static final Block AZALEA_FENCE = registerBlock("azalea_fence",
             new FenceBlock(FabricBlockSettings.copy(Blocks.OAK_FENCE).mapColor(MapColor.TERRACOTTA_GRAY)));
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,8 +29,8 @@
   "depends": {
     "fabricloader": ">=0.14.19",
     "fabric-api": "*",
-    "minecraft": ">=1.19.3",
+    "minecraft": ">=1.20.3",
     "java": ">=17",
-    "terraform-wood-api-v1": ">=6.1.0"
+    "terraform-wood-api-v1": ">=9.0.0"
   }
 }


### PR DESCRIPTION
update terraform-wood-api dependency
update mc version mappings/fabric-api
update block register formatting for new versions
update fabric.mod.json to allow for only 1.20.3+, as it crashes on older.